### PR TITLE
skip python<3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  skip: true # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:


### PR DESCRIPTION
I did not see @skupr-anaconda 's correction until after I hit merge. Fixing.